### PR TITLE
Evaluate specific Library Sections

### DIFF
--- a/plexondeckcache.py
+++ b/plexondeckcache.py
@@ -14,9 +14,6 @@ processed_files = []
 
 ##################################################################
 # Set the Sections we want to evaluate.                          #
-# Most users will have 1 & 2 as Films & TV, so                   #
-# should be safe to leave 1,2 as the default, rather than        #
-# defaulting to empty meaning handle all libraries.              #
 ##################################################################
 valid_sections = [1,2]
 

--- a/plexondeckcache.py
+++ b/plexondeckcache.py
@@ -12,36 +12,48 @@ PLEX_TOKEN = 'tokentokentoken'
 number_episodes = 5
 processed_files = []
 
+##################################################################
+# Set the Sections we want to evaluate.                          #
+# Most users will have 1 & 2 as Films & TV, so                   #
+# should be safe to leave 1,2 as the default, rather than        #
+# defaulting to empty meaning handle all libraries.              #
+##################################################################
+valid_sections = [1,2]
+
 if __name__ == '__main__':
     plex = PlexServer(PLEX_URL, PLEX_TOKEN)
     files = []
     for video in plex.library.onDeck():
-        #TV Series
-        if isinstance(video, Episode): 
-            for media in video.media:
-                for part in media.parts:
-                    show = video.grandparentTitle 
-                    # Get the library the video belongs to
-                    library_section = video.section()
-                    # Get the episodes of the show in the library
-                    episodes = [e for e in library_section.search(show)[0].episodes()] #Fetches the next 5 episodes
-                    next_episodes = []
-                    current_season = video.parentIndex
-                    files.append((part.file))
-                    for episode in episodes: 
-                        if episode.parentIndex > current_season or (episode.parentIndex == current_season and episode.index > video.index) and len(next_episodes) < number_episodes:
-                            next_episodes.append(episode) 
-                        if len(next_episodes) == number_episodes:
-                            break
-                    for episode in next_episodes: #Adds the episodes to the list
-                        for media in episode.media:
-                            for part in media.parts:
-                                files.append((part.file)) 
-        #Movies
-        else: 
-            for media in video.media:
-                for part in media.parts:
-                    files.append((part.file))
+        
+        # Apply section filter
+        if video.section().key in valid_sections:
+            
+            #TV Series
+            if isinstance(video, Episode): 
+                for media in video.media:
+                    for part in media.parts:
+                        show = video.grandparentTitle 
+                        # Get the library the video belongs to
+                        library_section = video.section()
+                        # Get the episodes of the show in the library
+                        episodes = [e for e in library_section.search(show)[0].episodes()] #Fetches the next 5 episodes
+                        next_episodes = []
+                        current_season = video.parentIndex
+                        files.append((part.file))
+                        for episode in episodes: 
+                            if episode.parentIndex > current_season or (episode.parentIndex == current_season and episode.index > video.index) and len(next_episodes) < number_episodes:
+                                next_episodes.append(episode) 
+                            if len(next_episodes) == number_episodes:
+                                break
+                        for episode in next_episodes: #Adds the episodes to the list
+                            for media in episode.media:
+                                for part in media.parts:
+                                    files.append((part.file)) 
+            #Movies
+            else: 
+                for media in video.media:
+                    for part in media.parts:
+                        files.append((part.file))
   
     #Search for subtitle files (any file with similar file name but different extension)
     processed_files = set()


### PR DESCRIPTION
This PR adds the ability to evaluate specific library sections. See #1 

As most users will have 1 & 2 as Films & TV, it should be safe to leave 1,2 as the default, rather than defaulting to empty meaning handle all libraries.

Had to add indentation to the blocks - which is why the diff shows them as being removed & added